### PR TITLE
flag mistake fixed in uninstalling packages example

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ An easy npm cheat sheet to makes developer life easier.
 
 ```bash
 > FORMAT: npm un <package-name>     # for local package
-> EX: npm i mongoose
+> EX: npm un mongoose
 
 > FORMAT: npm un -g <package-name> # for global package
 > EX: npm un -g npm-check-updates


### PR DESCRIPTION
In uninstalling packages section, format specified as `npm un <package-name>` but example used `npm i mongoose`